### PR TITLE
Populate AIMessage tool_calls to trigger function calling

### DIFF
--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -316,7 +316,7 @@ class ChatPromptAdapter:
         )
 
 
-_message_type_lookups = {"human": "user", "ai": "assistant"}
+_message_type_lookups = {"human": "user", "ai": "assistant", "tool": "user"}
 
 
 class ChatBedrock(BaseChatModel, BedrockBase):

--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -457,11 +457,18 @@ class ChatBedrock(BaseChatModel, BedrockBase):
                 llm_output["stop_reason"] = "end_turn"
 
         llm_output["model_id"] = self.model_id
-        ai_message = AIMessage(
-            content=completion,
-            tool_calls=tool_calls,
-            additional_kwargs=llm_output,
-        )
+
+        if tool_calls:
+            ai_message = AIMessage(
+                content=completion,
+                tool_calls=tool_calls,
+                additional_kwargs=llm_output,
+            )
+        else:
+            ai_message = AIMessage(
+                content=completion,
+                additional_kwargs=llm_output,
+            )
 
         return ChatResult(
             generations=[ChatGeneration(message=ai_message)],

--- a/libs/aws/langchain_aws/chat_models/bedrock.py
+++ b/libs/aws/langchain_aws/chat_models/bedrock.py
@@ -407,6 +407,8 @@ class ChatBedrock(BaseChatModel, BedrockBase):
         provider_stop_reason_code = self.provider_stop_reason_key_map.get(
             self._get_provider(), "stop_reason"
         )
+        tool_calls = []
+
         if self.streaming:
             response_metadata: List[Dict[str, Any]] = []
             for chunk in self._stream(messages, stop, run_manager, **kwargs):
@@ -455,12 +457,14 @@ class ChatBedrock(BaseChatModel, BedrockBase):
                 llm_output["stop_reason"] = "end_turn"
 
         llm_output["model_id"] = self.model_id
+        ai_message = AIMessage(
+            content=completion,
+            tool_calls=tool_calls,
+            additional_kwargs=llm_output,
+        )
+
         return ChatResult(
-            generations=[
-                ChatGeneration(
-                    message=AIMessage(content=completion, additional_kwargs=llm_output)
-                )
-            ],
+            generations=[ChatGeneration(message=ai_message)],
             llm_output=llm_output,
         )
 

--- a/libs/aws/langchain_aws/function_calling.py
+++ b/libs/aws/langchain_aws/function_calling.py
@@ -1,4 +1,4 @@
-"""Methods for creating function specs in the style of Bedrock Functions 
+"""Methods for creating function specs in the style of Bedrock Functions
 for supported model providers"""
 
 import json
@@ -12,6 +12,7 @@ from typing import (
     Union,
 )
 
+from langchain_core.messages import ToolCall
 from langchain_core.pydantic_v1 import BaseModel
 from langchain_core.tools import BaseTool
 from langchain_core.utils.function_calling import convert_to_openai_tool
@@ -139,8 +140,8 @@ def convert_to_anthropic_tool(
         )
 
 
-def parse_tool_calls_from_xml(xml_str: str) -> List[Dict[Any, Any]]:
-    tool_calls: List[Dict[Any, Any]] = []
+def parse_tool_calls_from_xml(xml_str: str) -> List[ToolCall]:
+    tool_calls: List[ToolCall] = []
     invokes = xml_str.split("<invoke>")[1:]
     for invoke in invokes:
         tool_name = invoke.split("<tool_name>")[1].split("</tool_name>")[0]
@@ -154,8 +155,10 @@ def parse_tool_calls_from_xml(xml_str: str) -> List[Dict[Any, Any]]:
             tag = tag.strip()
             value = value.split("</")[0]
             parameters[tag] = value
-        tool_call = {
-            "function": {"name": tool_name, "arguments": parameters, "type": "function"}
-        }
+        tool_call = ToolCall(
+            name=tool_name,
+            args=parameters,
+            id=None,
+        )
         tool_calls.append(tool_call)
     return tool_calls

--- a/libs/aws/langchain_aws/function_calling.py
+++ b/libs/aws/langchain_aws/function_calling.py
@@ -1,7 +1,9 @@
 """Methods for creating function specs in the style of Bedrock Functions
 for supported model providers"""
 
+import base64
 import json
+import uuid
 from typing import (
     Any,
     Callable,
@@ -158,7 +160,13 @@ def parse_tool_calls_from_xml(xml_str: str) -> List[ToolCall]:
         tool_call = ToolCall(
             name=tool_name,
             args=parameters,
-            id=None,
+            id=generate_tool_call_id(),
         )
         tool_calls.append(tool_call)
     return tool_calls
+
+
+def generate_tool_call_id() -> str:
+    random_bytes = uuid.uuid4().bytes
+    encoded_bytes = base64.urlsafe_b64encode(random_bytes).rstrip(b"=")
+    return f"call_{encoded_bytes.decode('utf-8')}"


### PR DESCRIPTION
The tool_calls instance attribute on AIMessage was not set. This PR adjusts the output of the `parse_tool_calls_from_xml` function, returning a List[ToolCall] also setting a random tool call ID upon parsing. This is then assigned to the AIMessage tool_call instance attribute. Messages of type 'tool' are set to be "user" responses in the context of the Bedrock user/assistant exchange.